### PR TITLE
add parameter ssl = false

### DIFF
--- a/celai_chatwoot/connector/bot_utils.py
+++ b/celai_chatwoot/connector/bot_utils.py
@@ -22,7 +22,8 @@ class ChatwootAgentsBots:
         url = f"{self.base_url}/api/v1/accounts/{self.account_id}/agent_bots"
         log.debug(f"Listing agent bots from Chatwoot url: {url}")
 
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
+        #async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
             async with session.get(url, headers=self.headers) as response:
                 response_data = await response.json()
                 return response_data
@@ -44,7 +45,7 @@ class ChatwootAgentsBots:
 
         payload = {k: v for k, v in payload.items() if v is not None}
 
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
             async with session.post(url, json=payload, headers=self.headers) as response:
                 response_data = await response.json()
                 return response_data
@@ -53,7 +54,7 @@ class ChatwootAgentsBots:
         url = f"{self.base_url}/api/v1/accounts/{self.account_id}/agent_bots/{agent_bot_id}"
         log.debug(f"Deleting agent bot from Chatwoot url: {url}")
 
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
             async with session.delete(url, headers=self.headers) as response:
                 response_data = await response.json()
                 return response_data
@@ -62,7 +63,7 @@ class ChatwootAgentsBots:
         url = f"{self.base_url}/api/v1/accounts/{self.account_id}/agent_bots/{agent_bot_id}"
         log.debug(f"Getting agent bot from Chatwoot url: {url}")
 
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
             async with session.get(url, headers=self.headers) as response:
                 response_data = await response.json()
                 return response_data
@@ -84,8 +85,8 @@ class ChatwootAgentsBots:
         }
 
         payload = {k: v for k, v in payload.items() if v is not None}
-
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
+        #async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
             async with session.patch(url, json=payload, headers=self.headers) as response:
                 response_data = await response.json()
                 return response_data
@@ -123,7 +124,7 @@ class ChatwootAgentsBots:
             'agent_bot': agent_bot_id
         }
 
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
             async with session.post(url, json=payload, headers=self.headers) as response:
                 response_data = await response.json()
                 return response_data

--- a/celai_chatwoot/connector/bot_utils.py
+++ b/celai_chatwoot/connector/bot_utils.py
@@ -9,7 +9,8 @@ class ChatwootAgentsBots:
                  base_url: str, 
                  account_id: str, 
                  access_key: str, 
-                 headers: Optional[Dict[str, str]] = None):
+                 headers: Optional[Dict[str, str]] = None,
+                 ssl: bool = False):
         self.base_url = base_url
         self.account_id = account_id
         self.access_key = access_key
@@ -17,13 +18,13 @@ class ChatwootAgentsBots:
         self.headers.update({
             'api_access_token': access_key
         })
+        self.ssl = ssl
 
     async def list_agent_bots(self) -> Dict[str, Any]:
         url = f"{self.base_url}/api/v1/accounts/{self.account_id}/agent_bots"
         log.debug(f"Listing agent bots from Chatwoot url: {url}")
 
-        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
-        #async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=self.ssl)) as session:        
             async with session.get(url, headers=self.headers) as response:
                 response_data = await response.json()
                 return response_data
@@ -45,7 +46,7 @@ class ChatwootAgentsBots:
 
         payload = {k: v for k, v in payload.items() if v is not None}
 
-        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=self.ssl)) as session:
             async with session.post(url, json=payload, headers=self.headers) as response:
                 response_data = await response.json()
                 return response_data
@@ -63,7 +64,7 @@ class ChatwootAgentsBots:
         url = f"{self.base_url}/api/v1/accounts/{self.account_id}/agent_bots/{agent_bot_id}"
         log.debug(f"Getting agent bot from Chatwoot url: {url}")
 
-        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=self.ssl)) as session:
             async with session.get(url, headers=self.headers) as response:
                 response_data = await response.json()
                 return response_data
@@ -85,7 +86,7 @@ class ChatwootAgentsBots:
         }
 
         payload = {k: v for k, v in payload.items() if v is not None}
-        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=self.ssl)) as session:
         #async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
             async with session.patch(url, json=payload, headers=self.headers) as response:
                 response_data = await response.json()
@@ -124,7 +125,7 @@ class ChatwootAgentsBots:
             'agent_bot': agent_bot_id
         }
 
-        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=self.ssl)) as session:
             async with session.post(url, json=payload, headers=self.headers) as response:
                 response_data = await response.json()
                 return response_data

--- a/celai_chatwoot/connector/msg_utils.py
+++ b/celai_chatwoot/connector/msg_utils.py
@@ -57,7 +57,7 @@ class ChatwootMessages:
                 b64_img = content.split("base64,")[1]
             if content.startswith("http"):
                 # download the image
-                async with aiohttp.ClientSession() as session:
+                async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
                     async with session.get(content) as resp:
                         b64_img = base64.b64encode(await resp.read()).decode()
             if len(content) > 100:
@@ -78,7 +78,7 @@ class ChatwootMessages:
                 b64_audio = content.split("base64,")[1]
             if content.startswith("http"):
                 # download the audio
-                async with aiohttp.ClientSession() as session:
+                async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
                     async with session.get(content) as resp:
                         b64_audio = base64.b64encode(await resp.read()).decode()
                         
@@ -124,7 +124,7 @@ class ChatwootMessages:
         # Remove keys with None values
         payload = {k: v for k, v in payload.items() if v is not None}
 
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
             async with session.post(url, json=payload, headers=headers) as response:
                 response_data = await response.json()
                 return response_data
@@ -161,7 +161,7 @@ class ChatwootMessages:
                
         
         # Make the HTTP request
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
             try:
                 async with session.post(url, data=form, headers=self.headers) as response:
                     res = await response.json()

--- a/celai_chatwoot/connector/msg_utils.py
+++ b/celai_chatwoot/connector/msg_utils.py
@@ -24,7 +24,8 @@ class ChatwootMessages:
                  base_url: str, 
                  account_id: str, 
                  access_key: str, 
-                 headers: Optional[Dict[str, str]] = None):
+                 headers: Optional[Dict[str, str]] = None,
+                 ssl: bool = False):
         self.base_url = base_url
         self.account_id = account_id
         self.access_key = access_key
@@ -32,6 +33,7 @@ class ChatwootMessages:
         self.headers.update({
             'api_access_token': access_key
         })
+        self.ssl = ssl
         
         
     async def __build_content(self, attach: ChatwootAttachment):        
@@ -57,7 +59,7 @@ class ChatwootMessages:
                 b64_img = content.split("base64,")[1]
             if content.startswith("http"):
                 # download the image
-                async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
+                async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=self.ssl)) as session:
                     async with session.get(content) as resp:
                         b64_img = base64.b64encode(await resp.read()).decode()
             if len(content) > 100:
@@ -78,7 +80,7 @@ class ChatwootMessages:
                 b64_audio = content.split("base64,")[1]
             if content.startswith("http"):
                 # download the audio
-                async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
+                async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=self.ssl)) as session:
                     async with session.get(content) as resp:
                         b64_audio = base64.b64encode(await resp.read()).decode()
                         
@@ -124,7 +126,7 @@ class ChatwootMessages:
         # Remove keys with None values
         payload = {k: v for k, v in payload.items() if v is not None}
 
-        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=self.ssl)) as session:
             async with session.post(url, json=payload, headers=headers) as response:
                 response_data = await response.json()
                 return response_data
@@ -161,7 +163,7 @@ class ChatwootMessages:
                
         
         # Make the HTTP request
-        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False)) as session:
+        async with aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=self.ssl)) as session:
             try:
                 async with session.post(url, data=form, headers=self.headers) as response:
                     res = await response.json()

--- a/celai_chatwoot/connector/woo_connector.py
+++ b/celai_chatwoot/connector/woo_connector.py
@@ -34,7 +34,8 @@ class WootConnector(BaseConnector):
                  chatwoot_url: str,
                  inbox_id: str,
                  bot_description: str = "Celai Bot",
-                 stream_mode: StreamMode = StreamMode.SENTENCE):
+                 stream_mode: StreamMode = StreamMode.SENTENCE,
+                 ssl: bool = False):
         log.debug("Creating Chatwoot connector")
 
         self.router = APIRouter(prefix="/chatwoot")
@@ -52,6 +53,7 @@ class WootConnector(BaseConnector):
         self.inbox_id = inbox_id
         self.chatwoot_url = chatwoot_url
         self.bot_description = bot_description or "Celai generated Bot"
+        self.ssl = ssl
         
 
     def __create_routes(self, router: APIRouter):
@@ -169,7 +171,8 @@ class WootConnector(BaseConnector):
         log.debug(f"Sending message to Chatwoot acc: {lead.account_id}, inbox: {lead.inbox_id}, conv: {lead.conversation_id}, private:{is_private}, text: {text}")   
         client = ChatwootMessages(base_url=self.chatwoot_url,
                                   account_id=lead.account_id,
-                                  access_key=self.access_key)
+                                  access_key=self.access_key,
+                                  ssl=self.ssl)
             
         await client.send_text_message(conversation_id=lead.conversation_id,
                                        content=text,
@@ -193,7 +196,8 @@ class WootConnector(BaseConnector):
         
         client = ChatwootMessages(base_url=self.chatwoot_url,
                                   account_id=lead.account_id,
-                                  access_key=self.access_key)
+                                  access_key=self.access_key,
+                                  ssl=self.ssl)
         
         is_private = (metadata or {}).get("private", False)
               
@@ -215,7 +219,8 @@ class WootConnector(BaseConnector):
         
         client = ChatwootMessages(base_url=self.chatwoot_url,
                                   account_id=lead.account_id,
-                                  access_key=self.access_key)
+                                  access_key=self.access_key,
+                                  ssl=self.ssl)
         
         is_private = (metadata or {}).get("private", False)
         attach = ChatwootAttachment(type="audio",
@@ -258,7 +263,8 @@ class WootConnector(BaseConnector):
                 client = ChatwootAgentsBots(
                     base_url=self.chatwoot_url,
                     account_id=self.account_id,
-                    access_key=self.access_key
+                    access_key=self.access_key,
+                    ssl=self.ssl
                 )
                 
                 bot = await client.upsert_bot(name=self.bot_name,


### PR DESCRIPTION
This pull request includes changes to the `celai_chatwoot/connector/bot_utils.py` and `celai_chatwoot/connector/msg_utils.py` files to disable SSL verification in `aiohttp.ClientSession` for various asynchronous functions. This update aims to simplify the HTTP requests by bypassing SSL certificate verification.

### Updates to `bot_utils.py`:

* Modified `list_agent_bots`, `create_agent_bot`, `delete_agent_bot`, `get_agent_bot`, `update_agent_bot`, and `assign_bot_to_inbox` functions to use `aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False))` for HTTP requests. [[1]](diffhunk://#diff-675dd41a55cddc439fc64c515a90a19b3cf62646f1bd702065bea053a4836505L25-R26) [[2]](diffhunk://#diff-675dd41a55cddc439fc64c515a90a19b3cf62646f1bd702065bea053a4836505L47-R48) [[3]](diffhunk://#diff-675dd41a55cddc439fc64c515a90a19b3cf62646f1bd702065bea053a4836505L56-R57) [[4]](diffhunk://#diff-675dd41a55cddc439fc64c515a90a19b3cf62646f1bd702065bea053a4836505L65-R66) [[5]](diffhunk://#diff-675dd41a55cddc439fc64c515a90a19b3cf62646f1bd702065bea053a4836505L87-R89) [[6]](diffhunk://#diff-675dd41a55cddc439fc64c515a90a19b3cf62646f1bd702065bea053a4836505L126-R127)

### Updates to `msg_utils.py`:

* Modified `__build_content_image`, `__build_content_audio`, `send_text_message`, and `send_attachment` functions to use `aiohttp.ClientSession(connector=aiohttp.TCPConnector(ssl=False))` for HTTP requests. [[1]](diffhunk://#diff-43a35ef891dd8c56810686d73a573330a874ea3f3a5d4a39b84f1ad587237f5aL60-R60) [[2]](diffhunk://#diff-43a35ef891dd8c56810686d73a573330a874ea3f3a5d4a39b84f1ad587237f5aL81-R81) [[3]](diffhunk://#diff-43a35ef891dd8c56810686d73a573330a874ea3f3a5d4a39b84f1ad587237f5aL127-R127) [[4]](diffhunk://#diff-43a35ef891dd8c56810686d73a573330a874ea3f3a5d4a39b84f1ad587237f5aL164-R164)